### PR TITLE
Add control-plane-kubeadm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,5 @@
 template: ## Render templates with example required values.
 	@cd charts/capi-cluster && \
 		helm template --namespace example testcluster . -f tests/values.required.yaml
+	@cd charts/kubeadm-control-plane && \
+    		helm template --namespace example foo . -f tests/values.required.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # capi-chart
 
-Helm chart with Cluster API `Cluster` resource.
+Helm charts with Cluster API resources:
+- capi-cluster with `Cluster` resource,
+- kubeadm-control-plane with `KubeadmControlPlane` resource.
 
 ## Usage
 

--- a/charts/kubeadm-control-plane/.helmignore
+++ b/charts/kubeadm-control-plane/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kubeadm-control-plane/Chart.yaml
+++ b/charts/kubeadm-control-plane/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: kubeadm-control-plane
+description: A Helm chart with Cluster API KubeadmControlPlane resource
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the kubeadm-control-plane chart version.
+#
+# This version number should be incremented each time you make changes to the chart and its
+# templates, including the app version.
+#
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version of [Cluster API](https://github.com/kubernetes-sigs/cluster-api) that is used
+# for manifests.
+appVersion: "1.8.4"

--- a/charts/kubeadm-control-plane/templates/NOTES.txt
+++ b/charts/kubeadm-control-plane/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Get the Cluster resource by running these commands:
+
+kubectl get cluster --namespace {{ include "kubeadm.control-plane.metadata.namespace" . }} {{ include "kubeadm.control-plane.metadata.name" . }}

--- a/charts/kubeadm-control-plane/templates/_helpers.tpl
+++ b/charts/kubeadm-control-plane/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+    Print control plane name.
+    We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kubeadm.control-plane.metadata.name" -}}
+{{- .Values.metadata.name | default .Values.global.metadata.name | default .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+    Print namespace where the resources are deployed to.
+    We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kubeadm.control-plane.metadata.namespace" -}}
+{{- .Values.metadata.namespace | default .Values.global.metadata.namespace | default .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubeadm.control-plane.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubeadm.control-plane.metadata.labels" -}}
+helm.sh/chart: {{ include "kubeadm.control-plane.chart" . }}
+{{ include "kubeadm.control-plane.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubeadm.control-plane.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "kubeadm.control-plane.metadata.template-name" -}}
+{{- include "kubeadm.control-plane.metadata.name" . }}-controlplane
+{{- end }}

--- a/charts/kubeadm-control-plane/templates/kubeadmcontrolplane.yaml
+++ b/charts/kubeadm-control-plane/templates/kubeadmcontrolplane.yaml
@@ -1,0 +1,22 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: {{ include "kubeadm.control-plane.metadata.name" . }}
+  namespace: {{ include "kubeadm.control-plane.metadata.namespace" . }}
+  labels: {{- include "kubeadm.control-plane.metadata.labels" . | nindent 4 }}
+spec:
+  version: {{ .Values.kubernetesVersion | default .Values.global.kubernetesVersion }}
+  replicas: {{ .Values.replicas }}
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: {{ .Values.machineTemplate.infrastructureRef.apiVersion }}
+      kind: {{ .Values.machineTemplate.infrastructureRef.kind }}
+      name: {{ .Values.machineTemplate.infrastructureRef.name | default (include "kubeadm.control-plane.metadata.template-name" . ) }}
+      namespace: {{ .Values.machineTemplate.infrastructureRef.name | default (include "kubeadm.control-plane.metadata.namespace" . ) }}

--- a/charts/kubeadm-control-plane/tests/values.global.yaml
+++ b/charts/kubeadm-control-plane/tests/values.global.yaml
@@ -1,0 +1,8 @@
+#
+# Global values to are used across resources in this and other charts.
+#
+global:
+  metadata:
+    name: global-foo
+    namespace: global-example
+  kubernetesVersion: 1.29.1

--- a/charts/kubeadm-control-plane/tests/values.required.yaml
+++ b/charts/kubeadm-control-plane/tests/values.required.yaml
@@ -1,0 +1,4 @@
+machineTemplate:
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.example.com/v1beta9
+    kind: ExampleMachineTemplate

--- a/charts/kubeadm-control-plane/values.yaml
+++ b/charts/kubeadm-control-plane/values.yaml
@@ -1,0 +1,22 @@
+metadata:
+  name: "" # If not specified, .global.metadata.name is used
+  namespace: "" # If not specified, .global.metadata.namespace is used
+
+kubernetesVersion: 1.31.0 # If not specified, .global.kubernetesVersion is used
+replicas: 3
+
+machineTemplate:
+  infrastructureRef:
+    apiVersion: ""
+    kind: ""
+    name: ""
+    namespace: ""
+
+#
+# Global values to are used across resources in this and other charts.
+#
+global:
+  metadata:
+    name: "" # If not specified, Helm release name is used
+    namespace: "" # If not specified, Helm release namespace is used
+  kubernetesVersion: ""


### PR DESCRIPTION
What's inside:

- Basic Helm chart boilerplate
- KubeadmControlPlane resource
- values.yaml with required and optional values for KubeadmControlPlane resource
- example values for required values and global values
- Makefile with a target to render Helm chart locally